### PR TITLE
CON-3261: fix location of AWS account id in example

### DIFF
--- a/examples/ecr-config/main.tf
+++ b/examples/ecr-config/main.tf
@@ -3,7 +3,7 @@ module "ecr-config" {
   uptycs_account_id = "cloudquery"
 
   # Copy the AWS Account ID from Uptycs UI
-  # Uptycs' UI : "Cloud"->"AWS"->"Integrations"->"ACCOUNT INTEGRATION"
+  # Uptycs' UI : "Configurations"->"Registry Configuration"->"ADD REGISTRY"
   external_id   = "Uptycs-AWS-ACCOUNT-ID"
 }
 


### PR DESCRIPTION
This PR updates the documentation on where to find the account ID for performing an ECR registry integration.