### PR TITLE
Add support for tags, use terraform fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ module "ecr-config" {
   # Copy the AWS Account ID from Uptycs UI
   # Uptycs' UI : "Configurations"->"Registry Configuration"->"ADD REGISTRY"
   external_id = "Uptycs-AWS-ACCOUNT-ID"
+
+  tags = {
+    Integration     = "uptycs"
+  }
 }
 
 output "aws_ecr_role_arn" {
@@ -50,6 +54,7 @@ output "aws_ecr_role_arn" {
 | ----------------- | --------------------------------------------------------------------- | -------- | -------- |
 | uptycs_account_id | Aws account id of Uptycs                                              | `string` | Yes      |
 | external_id       | Role external ID provided by Uptycs. Copy the UUID ID from Uptycs' UI | `string` | Yes      |
+| tags              | Tags to apply to the resources created by this module                 | `map`    | No       |
 
 <br/>
 

--- a/examples/ecr-config/main.tf
+++ b/examples/ecr-config/main.tf
@@ -5,6 +5,10 @@ module "ecr-config" {
   # Copy the AWS Account ID from Uptycs UI
   # Uptycs' UI : "Configurations"->"Registry Configuration"->"ADD REGISTRY"
   external_id   = "Uptycs-AWS-ACCOUNT-ID"
+
+  tags = {
+    Integration     = "uptycs"
+  }
 }
 
 output "aws_ecr_role_arn" {

--- a/main.tf
+++ b/main.tf
@@ -3,27 +3,29 @@
  */
 
 data "aws_iam_policy_document" "role_uptycs_trust" {
-    statement {
-        effect = "Allow"
-        actions = ["sts:AssumeRole"]
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
 
-        principals {
-            type = "AWS"
-            identifiers = [var.uptycs_account_id]
-        }
-
-        condition {
-            test     = "StringEquals"
-            variable = "sts:ExternalId"
-            values = [var.external_id]
-        }
+    principals {
+      type        = "AWS"
+      identifiers = [var.uptycs_account_id]
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [var.external_id]
+    }
+  }
 }
 
 resource "aws_iam_role" "uptycs_integration_role" {
-    assume_role_policy = data.aws_iam_policy_document.role_uptycs_trust.json
+  assume_role_policy = data.aws_iam_policy_document.role_uptycs_trust.json
 
-    managed_policy_arns = [
-        "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-    ]
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  ]
+
+  tags = var.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,11 +3,11 @@
  */
 
 output "role_arn" {
-    description = "ARN of the created role, please update this back on Uptycs' UI"
-    value = aws_iam_role.uptycs_integration_role.arn
+  description = "ARN of the created role, please update this back on Uptycs' UI"
+  value       = aws_iam_role.uptycs_integration_role.arn
 }
 
 output "external_id" {
-    description = "ExternalId associated with the role, please update this back on Uptycs' UI"
-    value = var.external_id
+  description = "ExternalId associated with the role, please update this back on Uptycs' UI"
+  value       = var.external_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,14 +2,20 @@
  * Copyright (c) 2023 Uptycs, Inc. All rights reserved
  */
 
-variable uptycs_account_id {
-    description = "Aws account id of Uptycs"
-    type = string
-    # default = "${UPTYCS_AWS_KSPM_ACCOUNT_ID}"
+variable "uptycs_account_id" {
+  description = "Aws account id of Uptycs"
+  type        = string
+  # default = "${UPTYCS_AWS_KSPM_ACCOUNT_ID}"
 }
 
-variable external_id {
-    description = "ExternalId to be used for API authentication."
-    type = string
-    # default = "${EXTERNAL_ID}"
+variable "external_id" {
+  description = "ExternalId to be used for API authentication."
+  type        = string
+  # default = "${EXTERNAL_ID}"
+}
+
+variable "tags" {
+  description = "Tags to apply to the resources created by this module"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
Hey all, in the module docs, it shows using tags:
https://registry.terraform.io/modules/uptycslabs/ecr-config/aws/latest

However, in the code, there was no such support. I've added the bits to make that example code work and also ran `terraform fmt` to format the code.